### PR TITLE
Added SILENT message slot.

### DIFF
--- a/src/aiozyre/util.pyx
+++ b/src/aiozyre/util.pyx
@@ -29,7 +29,8 @@ MSG_SLOTS = {
     'JOIN': ('peer', 'name', 'group'),
     'LEAVE': ('peer', 'name', 'group'),
     'WHISPER': ('peer', 'name', 'blob'),
-    'SHOUT': ('peer', 'name', 'group', 'blob')
+    'SHOUT': ('peer', 'name', 'group', 'blob'),
+    'SILENT': ('peer', 'name')
 }
 BIN_SLOTS = ('blob',)
 


### PR DESCRIPTION
SILENT will bubble up from Zyre when a peer is lost.  Don't really need to use it, just stop an exception from throwing.